### PR TITLE
Add Windows support

### DIFF
--- a/CheckPCI.bat
+++ b/CheckPCI.bat
@@ -1,0 +1,426 @@
+@echo off
+REM Get our local path and args before delayed expansion - allows % and !
+set "thisDir=%~dp0"
+set "args=%*"
+
+setlocal enableDelayedExpansion
+REM Setup initial vars
+set "script_name="
+set /a tried=0
+set "toask=yes"
+set "pause_on_error=yes"
+set "py2v="
+set "py2path="
+set "py3v="
+set "py3path="
+set "pypath="
+set "targetpy=3"
+
+REM use_py3:
+REM   TRUE  = Use if found, use py2 otherwise
+REM   FALSE = Use py2
+REM   FORCE = Use py3
+set "use_py3=TRUE"
+
+REM We'll parse if the first argument passed is
+REM --install-python and if so, we'll just install
+REM Can optionally take a version number as the
+REM second arg - i.e. --install-python 3.13.1
+set "just_installing=FALSE"
+set "user_provided="
+
+REM Get the system32 (or equivalent) path
+call :getsyspath "syspath"
+
+REM Make sure the syspath exists
+if "!syspath!" == "" (
+    if exist "%SYSTEMROOT%\system32\cmd.exe" (
+        if exist "%SYSTEMROOT%\system32\reg.exe" (
+            if exist "%SYSTEMROOT%\system32\where.exe" (
+                REM Fall back on the default path if it exists
+                set "ComSpec=%SYSTEMROOT%\system32\cmd.exe"
+                set "syspath=%SYSTEMROOT%\system32\"
+            )
+        )
+    )
+    if "!syspath!" == "" (
+        cls
+        echo   ###                      ###
+        echo  #  Missing Required Files  #
+        echo ###                      ###
+        echo.
+        echo Could not locate cmd.exe, reg.exe, or where.exe
+        echo.
+        echo Please ensure your ComSpec environment variable is properly configured and
+        echo points directly to cmd.exe, then try again.
+        echo.
+        echo Current CompSpec Value: "%ComSpec%"
+        echo.
+        echo Press [enter] to quit.
+        pause > nul
+        exit /b 1
+    )
+)
+
+if "%~1" == "--install-python" (
+    set "just_installing=TRUE"
+    set "user_provided=%~2"
+    goto installpy
+)
+
+goto checkscript
+
+:checkscript
+REM Check for our script first
+set "looking_for=!script_name!"
+if "!script_name!" == "" (
+    set "looking_for=%~n0.py or %~n0.command"
+    set "script_name=%~n0.py"
+    if not exist "!thisDir!\!script_name!" (
+        set "script_name=%~n0.command"
+    )
+)
+if not exist "!thisDir!\!script_name!" (
+    cls
+    echo   ###                      ###
+    echo  #     Target Not Found     #
+    echo ###                      ###
+    echo.
+    echo Could not find !looking_for!.
+    echo Please make sure to run this script from the same directory
+    echo as !looking_for!.
+    echo.
+    echo Press [enter] to quit.
+    pause > nul
+    exit /b 1
+)
+goto checkpy
+
+:checkpy
+call :updatepath
+for /f "USEBACKQ tokens=*" %%x in (`!syspath!where.exe python 2^> nul`) do ( call :checkpyversion "%%x" "py2v" "py2path" "py3v" "py3path" )
+for /f "USEBACKQ tokens=*" %%x in (`!syspath!where.exe python3 2^> nul`) do ( call :checkpyversion "%%x" "py2v" "py2path" "py3v" "py3path" )
+for /f "USEBACKQ tokens=*" %%x in (`!syspath!where.exe py 2^> nul`) do ( call :checkpylauncher "%%x" "py2v" "py2path" "py3v" "py3path" )
+REM Walk our returns to see if we need to install
+if /i "!use_py3!" == "FALSE" (
+    set "targetpy=2"
+    set "pypath=!py2path!"
+) else if /i "!use_py3!" == "FORCE" (
+    set "pypath=!py3path!"
+) else if /i "!use_py3!" == "TRUE" (
+    set "pypath=!py3path!"
+    if "!pypath!" == "" set "pypath=!py2path!"
+)
+if not "!pypath!" == "" (
+    goto runscript
+)
+if !tried! lss 1 (
+    if /i "!toask!"=="yes" (
+        REM Better ask permission first
+        goto askinstall
+    ) else (
+        goto installpy
+    )
+) else (
+    cls
+    echo   ###                      ###
+    echo  #     Python Not Found     #
+    echo ###                      ###
+    echo.
+    REM Couldn't install for whatever reason - give the error message
+    echo Python is not installed or not found in your PATH var.
+    echo Please go to https://www.python.org/downloads/windows/ to
+    echo download and install the latest version, then try again.
+    echo.
+    echo Make sure you check the box labeled:
+    echo.
+    echo "Add Python X.X to PATH"
+    echo.
+    echo Where X.X is the py version you're installing.
+    echo.
+    echo Press [enter] to quit.
+    pause > nul
+    exit /b 1
+)
+goto runscript
+
+:checkpylauncher <path> <py2v> <py2path> <py3v> <py3path>
+REM Attempt to check the latest python 2 and 3 versions via the py launcher
+for /f "USEBACKQ tokens=*" %%x in (`%~1 -2 -c "import sys; print(sys.executable)" 2^> nul`) do ( call :checkpyversion "%%x" "%~2" "%~3" "%~4" "%~5" )
+for /f "USEBACKQ tokens=*" %%x in (`%~1 -3 -c "import sys; print(sys.executable)" 2^> nul`) do ( call :checkpyversion "%%x" "%~2" "%~3" "%~4" "%~5" )
+goto :EOF
+
+:checkpyversion <path> <py2v> <py2path> <py3v> <py3path>
+set "version="&for /f "tokens=2* USEBACKQ delims= " %%a in (`"%~1" -V 2^>^&1`) do (
+    REM Ensure we have a version number
+    call :isnumber "%%a"
+    if not "!errorlevel!" == "0" goto :EOF
+    set "version=%%a"
+)
+if not defined version goto :EOF
+if "!version:~0,1!" == "2" (
+    REM Python 2
+    call :comparepyversion "!version!" "!%~2!"
+    if "!errorlevel!" == "1" (
+        set "%~2=!version!"
+        set "%~3=%~1"
+    )
+) else (
+    REM Python 3
+    call :comparepyversion "!version!" "!%~4!"
+    if "!errorlevel!" == "1" (
+        set "%~4=!version!"
+        set "%~5=%~1"
+    )
+)
+goto :EOF
+
+:isnumber <check_value>
+set "var="&for /f "delims=0123456789." %%i in ("%~1") do set var=%%i
+if defined var (exit /b 1)
+exit /b 0
+
+:comparepyversion <version1> <version2> <return>
+REM Exits with status 0 if equal, 1 if v1 gtr v2, 2 if v1 lss v2
+for /f "tokens=1,2,3 delims=." %%a in ("%~1") do (
+    set a1=%%a
+    set a2=%%b
+    set a3=%%c
+)
+for /f "tokens=1,2,3 delims=." %%a in ("%~2") do (
+    set b1=%%a
+    set b2=%%b
+    set b3=%%c
+)
+if not defined a1 set a1=0
+if not defined a2 set a2=0
+if not defined a3 set a3=0
+if not defined b1 set b1=0
+if not defined b2 set b2=0
+if not defined b3 set b3=0
+if %a1% gtr %b1% exit /b 1
+if %a1% lss %b1% exit /b 2
+if %a2% gtr %b2% exit /b 1
+if %a2% lss %b2% exit /b 2
+if %a3% gtr %b3% exit /b 1
+if %a3% lss %b3% exit /b 2
+exit /b 0
+
+:askinstall
+cls
+echo   ###                      ###
+echo  #     Python Not Found     #
+echo ###                      ###
+echo.
+echo Python !targetpy! was not found on the system or in the PATH var.
+echo.
+set /p "menu=Would you like to install it now? [y/n]: "
+if /i "!menu!"=="y" (
+    REM We got the OK - install it
+    goto installpy
+) else if "!menu!"=="n" (
+    REM No OK here...
+    set /a tried=!tried!+1
+    goto checkpy
+)
+REM Incorrect answer - go back
+goto askinstall
+
+:installpy
+REM This will attempt to download and install python
+set /a tried=!tried!+1
+cls
+echo   ###                        ###
+echo  #     Downloading Python     #
+echo ###                        ###
+echo.
+set "release=!user_provided!"
+if "!release!" == "" (
+    REM No explicit release set - get the latest from python.org
+    echo Gathering latest version...
+    powershell -command "[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;(new-object System.Net.WebClient).DownloadFile('https://www.python.org/downloads/windows/','%TEMP%\pyurl.txt')"
+    REM Extract it if it's gzip compressed
+    powershell -command "$infile='%TEMP%\pyurl.txt';$outfile='%TEMP%\pyurl.temp';try{$input=New-Object System.IO.FileStream $infile,([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read);$output=New-Object System.IO.FileStream $outfile,([IO.FileMode]::Create),([IO.FileAccess]::Write),([IO.FileShare]::None);$gzipStream=New-Object System.IO.Compression.GzipStream $input,([IO.Compression.CompressionMode]::Decompress);$buffer=New-Object byte[](1024);while($true){$read=$gzipstream.Read($buffer,0,1024);if($read -le 0){break};$output.Write($buffer,0,$read)};$gzipStream.Close();$output.Close();$input.Close();Move-Item -Path $outfile -Destination $infile -Force}catch{}"
+    if not exist "%TEMP%\pyurl.txt" (
+        if /i "!just_installing!" == "TRUE" (
+            echo  - Failed to get info
+            exit /b 1
+        ) else (
+            goto checkpy
+        )
+    )
+    pushd "%TEMP%"
+    :: Version detection code slimmed by LussacZheng (https://github.com/corpnewt/gibMacOS/issues/20)
+    for /f "tokens=9 delims=< " %%x in ('findstr /i /c:"Latest Python !targetpy! Release" pyurl.txt') do ( set "release=%%x" )
+    popd
+    REM Let's delete our txt file now - we no longer need it
+    del "%TEMP%\pyurl.txt"
+    if "!release!" == "" (
+        if /i "!just_installing!" == "TRUE" (
+            echo  - Failed to get python version
+            exit /b 1
+        ) else (
+            goto checkpy
+        )
+    )
+    echo Located Version:  !release!
+) else (
+    echo User-Provided Version:  !release!
+    REM Update our targetpy to reflect the first number of
+    REM our release
+    for /f "tokens=1 delims=." %%a in ("!release!") do (
+        call :isnumber "%%a"
+        if "!errorlevel!" == "0" (
+            set "targetpy=%%a"
+        )
+    )
+)
+echo Building download url...
+REM At this point - we should have the version number.
+REM We can build the url like so: "https://www.python.org/ftp/python/[version]/python-[version]-amd64.exe"
+set "url=https://www.python.org/ftp/python/!release!/python-!release!-amd64.exe"
+set "pytype=exe"
+if "!targetpy!" == "2" (
+    set "url=https://www.python.org/ftp/python/!release!/python-!release!.amd64.msi"
+    set "pytype=msi"
+)
+echo  - !url!
+echo Downloading...
+REM Now we download it with our slick powershell command
+powershell -command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (new-object System.Net.WebClient).DownloadFile('!url!','%TEMP%\pyinstall.!pytype!')"
+REM If it doesn't exist - we bail
+if not exist "%TEMP%\pyinstall.!pytype!" (
+    if /i "!just_installing!" == "TRUE" (
+        echo  - Failed to download python installer
+        exit /b 1
+    ) else (
+        goto checkpy
+    )
+)
+REM It should exist at this point - let's run it to install silently
+echo Running python !pytype! installer...
+pushd "%TEMP%"
+if /i "!pytype!" == "exe" (
+    echo  - pyinstall.exe /quiet PrependPath=1 Include_test=0 Shortcuts=0 Include_launcher=0
+    pyinstall.exe /quiet PrependPath=1 Include_test=0 Shortcuts=0 Include_launcher=0
+) else (
+    set "foldername=!release:.=!"
+    echo  - msiexec /i pyinstall.msi /qb ADDLOCAL=ALL TARGETDIR="%LocalAppData%\Programs\Python\Python!foldername:~0,2!"
+    msiexec /i pyinstall.msi /qb ADDLOCAL=ALL TARGETDIR="%LocalAppData%\Programs\Python\Python!foldername:~0,2!"
+)
+popd
+set "py_error=!errorlevel!"
+echo Installer finished with status: !py_error!
+echo Cleaning up...
+REM Now we should be able to delete the installer and check for py again
+del "%TEMP%\pyinstall.!pytype!"
+REM If it worked, then we should have python in our PATH
+REM this does not get updated right away though - let's try
+REM manually updating the local PATH var
+call :updatepath
+if /i "!just_installing!" == "TRUE" (
+    echo.
+    echo Done.
+) else (
+    goto checkpy
+)
+exit /b
+
+:runscript
+REM Python found
+cls
+REM Checks the args gathered at the beginning of the script.
+REM Make sure we're not just forwarding empty quotes.
+set "arg_test=!args:"=!"
+if "!arg_test!"=="" (
+    "!pypath!" "!thisDir!!script_name!"
+) else (
+    "!pypath!" "!thisDir!!script_name!" !args!
+)
+if /i "!pause_on_error!" == "yes" (
+    if not "%ERRORLEVEL%" == "0" (
+        echo.
+        echo Script exited with error code: %ERRORLEVEL%
+        echo.
+        echo Press [enter] to exit...
+        pause > nul
+    )
+)
+goto :EOF
+
+:undouble <string_name> <string_value> <character>
+REM Helper function to strip doubles of a single character out of a string recursively
+set "string_value=%~2"
+:undouble_continue
+set "check=!string_value:%~3%~3=%~3!"
+if not "!check!" == "!string_value!" (
+    set "string_value=!check!"
+    goto :undouble_continue
+)
+set "%~1=!check!"
+goto :EOF
+
+:updatepath
+set "spath="
+set "upath="
+for /f "USEBACKQ tokens=2* delims= " %%i in (`!syspath!reg.exe query "HKCU\Environment" /v "Path" 2^> nul`) do ( if not "%%j" == "" set "upath=%%j" )
+for /f "USEBACKQ tokens=2* delims= " %%i in (`!syspath!reg.exe query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" 2^> nul`) do ( if not "%%j" == "" set "spath=%%j" )
+if not "%spath%" == "" (
+    REM We got something in the system path
+    set "PATH=%spath%"
+    if not "%upath%" == "" (
+        REM We also have something in the user path
+        set "PATH=%PATH%;%upath%"
+    )
+) else if not "%upath%" == "" (
+    set "PATH=%upath%"
+)
+REM Remove double semicolons from the adjusted PATH
+call :undouble "PATH" "%PATH%" ";"
+goto :EOF
+
+:getsyspath <variable_name>
+REM Helper method to return a valid path to cmd.exe, reg.exe, and where.exe by
+REM walking the ComSpec var - will also repair it in memory if need be
+REM Strip double semi-colons
+call :undouble "temppath" "%ComSpec%" ";"
+
+REM Dirty hack to leverage the "line feed" approach - there are some odd side
+REM effects with this.  Do not use this variable name in comments near this
+REM line - as it seems to behave erradically.
+(set LF=^
+%=this line is empty=%
+)
+REM Replace instances of semi-colons with a line feed and wrap
+REM in parenthesis to work around some strange batch behavior
+set "testpath=%temppath:;=!LF!%"
+
+REM Let's walk each path and test if cmd.exe, reg.exe, and where.exe exist there
+set /a found=0
+for /f "tokens=* delims=" %%i in ("!testpath!") do (
+    REM Only continue if we haven't found it yet
+    if not "%%i" == "" (
+        if !found! lss 1 (
+            set "checkpath=%%i"
+            REM Remove "cmd.exe" from the end if it exists
+            if /i "!checkpath:~-7!" == "cmd.exe" (
+                set "checkpath=!checkpath:~0,-7!"
+            )
+            REM Pad the end with a backslash if needed
+            if not "!checkpath:~-1!" == "\" (
+                set "checkpath=!checkpath!\"
+            )
+            REM Let's see if cmd, reg, and where exist there - and set it if so
+            if EXIST "!checkpath!cmd.exe" (
+                if EXIST "!checkpath!reg.exe" (
+                    if EXIST "!checkpath!where.exe" (
+                        set /a found=1
+                        set "ComSpec=!checkpath!cmd.exe"
+                        set "%~1=!checkpath!"
+                    )
+                )
+            )
+        )
+    )
+)
+goto :EOF

--- a/CheckPCI.py
+++ b/CheckPCI.py
@@ -292,7 +292,7 @@ class CheckPCI:
                     continue # No match
             # Parse the info based on our columns
             row = self.get_row(
-                row if include_names else row[:-1],
+                row if sys.platform.lower()=="darwin" or include_names else row[:-1],
                 column_list=display_columns
             )
             if row[-check_back:] == r["row"][-check_back:]:

--- a/CheckPCI.py
+++ b/CheckPCI.py
@@ -1,22 +1,180 @@
-import os, sys, binascii, argparse
-from Scripts import ioreg, utils
+import os, sys, binascii, argparse, re
+from Scripts import ioreg, utils, run
 
 class CheckPCI:
     def __init__(self):
         # Verify running OS
-        if not sys.platform.lower() == "darwin":
-            print("This script can only be run on macOS!")
+        if not sys.platform.lower() == "darwin" and not os.name == "nt":
+            print("This script can only be run on macOS or Windows!")
             exit(1)
         self.u = utils.Utils("CheckPCI")
         self.i = ioreg.IOReg()
-        self.default_columns = (
-            ("PCIDBG",7),
-            ("VEN:DEV",9),
-            ("Built-In",8),
-            ("Bridged",7),
-            ("ACPI",0),
-            ("Device",0)
-        )
+        self.r = run.Run()
+        if os.name == "nt":
+            self.default_columns = [
+                ("PCIDBG",7),
+                ("VEN:DEV",9),
+                ("Bridged",7),
+                ("ACPI",0),
+                ("Device",0)
+            ]
+        else:
+            self.default_columns = (
+                ("PCIDBG",7),
+                ("VEN:DEV",9),
+                ("Built-In",8),
+                ("Bridged",7),
+                ("ACPI",0),
+                ("Device",0)
+            )
+
+    def hexy(self, integer,pad_to=0):
+        return "0x"+hex(integer)[2:].upper().rjust(pad_to,"0")
+
+    def sanitize_device_path(self, device_path):
+        # Walk the device_path, gather the addresses, and rebuild it
+        if not device_path or not device_path.lower().startswith("pciroot("):
+            # Not a device path - bail
+            return
+        # Strip out PciRoot() and Pci() - then split by separators
+        adrs = re.split(r"#|\/",device_path.lower().replace("pciroot(","").replace("pci(","").replace(")",""))
+        new_path = []
+        overflow_path = []
+        for i,adr in enumerate(adrs):
+            if i == 0:
+                # Check for roots
+                if "," in adr: return # Broken
+                try:
+                    adr = int(adr,16)
+                    new_path.append("PciRoot({})".format(self.hexy(adr)))
+                    overflow_path.append("PciRoot({})".format(self.hexy(0 if adr>0xFF else adr)))
+                except: return # Broken again :(
+            else:
+                if "," in adr: # Not Windows formatted
+                    try: adr1,adr2 = [int(x,16) for x in adr.split(",")]
+                    except: return # REEEEEEEEEE
+                else:
+                    try:
+                        adr = int(adr,16)
+                        adr2,adr1 = adr & 0xFF, adr >> 8 & 0xFF
+                    except: return # AAAUUUGGGHHHHHHHH
+                # Should have adr1 and adr2 - let's add them
+                new_path.append("Pci({},{})".format(self.hexy(adr1),self.hexy(adr2)))
+                overflow_path.append("Pci({},{})".format(
+                    self.hexy(0 if adr1>0xFF else adr1),
+                    self.hexy(0 if adr2>0xFF else adr2)
+                ))
+        return ("/".join(new_path),"/".join(overflow_path))
+
+    def format_acpi_path(self, acpi_path):
+        if not acpi_path or not acpi_path.lower().startswith("acpi("):
+            return
+        acpi_comps = []
+        for a in acpi_path.upper().split("#"):
+            if a.startswith("ACPI("):
+                # Got an APCI entry - unwrap it
+                acpi_comps.append(a.split("ACPI(")[1].split(")")[0])
+            elif a.startswith("PCI("):
+                # This is abridge - just take note
+                acpi_comps.append("pci-bridge")
+        if not all(len(x)<=4 or x=="pci-bridge" for x in acpi_comps):
+            # Broken somehow?
+            return
+        # Return the resulting path
+        return ".".join(acpi_comps)
+
+    def get_pci_dict(self):
+        # Attempt to run a powershell one-liner to get a list of all
+        # instance ids which start with PCI
+        out = self.r.run({
+            "args":[
+                "powershell",
+                "-c",
+                "$devList=Get-PnpDevice|select -Property FriendlyName,InstanceId;foreach($d in $devList){$n=$d.FriendlyName;$d=$d.InstanceId;if($d.StartsWith(\"PCI\\\")){$l=Get-PnpDeviceProperty -KeyName DEVPKEY_Device_LocationInfo,DEVPKEY_Device_LocationPaths -InstanceId $d|select -Property Data;Write-Output $n $d $l}}"
+            ]
+        })[0].replace("\r","").split("\n")
+        if not out:
+            return None
+        # Walk the devices and their subsequent paths
+        dev = name = None
+        loc = "??:??.?"
+        dev_dict = {}
+        for l in out:
+            if not l.replace("-","").replace("Data","").strip():
+                continue # Skip empty lines and headers
+            if l.startswith("PCI\\"):
+                # Got a device
+                dev = l
+            elif l.startswith("{") and dev:
+                # Got the location paths
+                try:
+                    paths = l.split("{")[1].split("}")[0].split(", ")
+                    dev_path = next((p for p in paths if p.startswith("PCIROOT(")),None)
+                    acpi_path = next((p for p in paths if p.startswith("ACPI(")),None)
+                    bridged = "NO" if all(x.startswith("ACPI(") for x in acpi_path.split("#")) else "YES"
+                    try: ven_id = dev.split("VEN_")[1][:4]
+                    except: ven_id = "????"
+                    try: dev_id = dev.split("DEV_")[1][:4]
+                    except: dev_id = "????"
+                    dev_name = None
+                    if acpi_path.split("#")[-1].startswith("ACPI("):
+                        dev_name = acpi_path.split("ACPI(")[-1].split(")")[0]
+                    dev_paths = self.sanitize_device_path(dev_path)
+                    if not dev_paths:
+                        # Broken?
+                        continue
+                    acpi_formatted = self.format_acpi_path(acpi_path)
+                    if not acpi_formatted:
+                        continue
+                    dev_dict[dev] = {
+                        "pcidebug":loc,
+                        "device_path":dev_paths[0],
+                        "acpi_path":acpi_formatted,
+                        "bridged":bridged,
+                        "ven_dev":"{}:{}".format(ven_id,dev_id).lower()
+                    }
+                    if dev_name:
+                        dev_dict[dev]["name"] = dev_name
+                    if dev_paths[0] != dev_paths[1]:
+                        dev_dict[dev]["overflow_device_path"] = dev_paths[1]
+                    if name:
+                        dev_dict[dev]["friendly_name"] = name
+                except:
+                    pass
+                dev = name = None # Reset
+                loc = "??:??.?"
+            elif l.startswith("PCI bus "):
+                # Get our location info organizec the same way gfxutil does
+                try:
+                    a,b,c = [x.split()[-1] for x in l.split(", ")]
+                    loc = "{}:{}.{}".format(
+                        hex(int(a))[2:].rjust(2,"0"),
+                        hex(int(b))[2:].rjust(2,"0"),
+                        hex(int(c))[2:]
+                    )
+                except:
+                    pass
+            else:
+                # Got a friendly name
+                name = l.strip()
+        return dev_dict
+
+    def get_ps_entries(self):
+        all_devs = self.get_pci_dict()
+        rows = []
+        for p in all_devs.values():
+            rows.append({
+                "name":p.get("name",""),
+                "row":(
+                    p["pcidebug"],
+                    p["ven_dev"],
+                    p["bridged"],
+                    p["acpi_path"],
+                    p["device_path"],
+                    p.get("friendly_name","")
+                )
+            })
+        return rows
 
     def get_row(self, row, column_list=None):
         # Takes an interable row and compares with
@@ -46,32 +204,17 @@ class CheckPCI:
                 new_row.append(x)
         return new_row
 
-    def main(self,device_name=None,columns=None,column_match=None):
-        if device_name is not None and not isinstance(device_name,str):
-            device_name = str(device_name)
-        display_columns = []
-        if isinstance(columns,(list,tuple)):
-            for c in columns:
-                try:
-                    c = int(c)
-                    self.default_columns[c]
-                    if not c in display_columns:
-                        display_columns.append(c)
-                except:
-                    pass
-        else:
-            display_columns = None
+    def get_ioreg_entries(self):
         all_devs = self.i.get_all_devices()
-        dev_list = []
+        # Walk the entries and process them as needed - returning
+        # the values expected, in order
+        rows = []
         for p in all_devs.values():
             p_dict = p.get("info",{})
             ven = p_dict.get("vendor-id")
             dev = p_dict.get("device-id")
             if not (ven and dev):
                 continue # Missing info - skip
-            # Check our name if we are looking for one
-            if device_name and not p.get("name_no_addr","").lower() == device_name.lower():
-                continue # Not our device name - skip
             pcidebug = "??:??.?"
             if "pcidebug" in p_dict:
                 # Try to organize it the same way gfxutil does
@@ -100,7 +243,43 @@ class CheckPCI:
                 bridged = "NO"
             acpi = p.get("acpi_path","Unknown APCI Path")
             device = p.get("device_path","Unknown Device Path")
-            row = (pcidebug,vendev,builtin,bridged,acpi,device)
+            rows.append({
+                "name":p.get("name_no_addr",""),
+                "row":(pcidebug,vendev,builtin,bridged,acpi,device)
+            })
+        return rows
+
+    def main(self,device_name=None,columns=None,column_match=None,include_names=False):
+        if device_name is not None and not isinstance(device_name,str):
+            device_name = str(device_name)
+        if include_names:
+            self.default_columns.append(("FriendlyName",0))
+        display_columns = []
+        if isinstance(columns,(list,tuple)):
+            for c in columns:
+                try:
+                    c = int(c)
+                    self.default_columns[c]
+                    if not c in display_columns:
+                        display_columns.append(c)
+                except:
+                    pass
+        else:
+            display_columns = None
+        # Get our device list based on our OS
+        if os.name == "nt":
+            rows = self.get_ps_entries()
+            check_back = 3 # Look for ACPI, Device, "" on Windows
+        else:
+            rows = self.get_ioreg_entries()
+            check_back = 2 # Look for ACPI and Device on macOS
+        dev_list = []
+        # Iterate those devices
+        for r in rows:
+            # Check our name if we are looking for one
+            if device_name and not r.get("name","").lower() == device_name.lower():
+                continue # Not our device name - skip
+            row = r["row"]
             # Ensure our columns match if needed
             if column_match:
                 matched = True
@@ -113,13 +292,13 @@ class CheckPCI:
                     continue # No match
             # Parse the info based on our columns
             row = self.get_row(
-                row,
+                row if include_names else row[:-1],
                 column_list=display_columns
             )
-            if row[-2:] == [acpi,device]:
+            if row[-check_back:] == r["row"][-check_back:]:
                 # Special handler to join ACPI and Device paths
                 # with " = "
-                row = row[:-2]+[" = ".join([acpi,device])]
+                row = row[:-check_back]+[" = ".join(r["row"][-check_back:])]
             # Add to the list
             dev_list.append(" ".join(row))
         if not dev_list:
@@ -137,13 +316,14 @@ class CheckPCI:
             [x[0] for x in self.default_columns],
             column_list=display_columns
         )
-        # Join "ACPI" and "Device" with a "+"
-        if header_row[-2:] == ["ACPI","Device"]:
-            header_row = header_row[:-2]+["ACPI+Device"]
         dev_header = " ".join(header_row)
         # Append " Paths" if the last entry was a path
-        if dev_header.endswith(("ACPI","Device")):
-            dev_header += " Paths"
+        if "ACPI Device" in dev_header:
+            dev_header = dev_header.replace("ACPI Device","APCI+Device Paths")
+        else:
+            dev_header = dev_header.replace("ACPI","ACPI Paths").replace("Device","Device Paths")
+        dev_header = dev_header.replace("ACPI Device","ACPI+Device")
+        dev_header = dev_header.replace("ACPI+Device","ACPI+Device Paths")
         dev_list = [dev_header,"-"*len(dev_header)]+sorted(dev_list)
         print("\n".join(dev_list))
 
@@ -154,11 +334,16 @@ if __name__ == '__main__':
     # Setup the cli args
     parser = argparse.ArgumentParser(prog="CheckPCI.py", description="CheckPCI - a py script to list PCI device info from the IODeviceTree.")
     parser.add_argument("-f", "--find-name", help="find device paths for objects with the passed name from the IODeviceTree")
-    parser.add_argument("-i", "--local-ioreg", help="path to local ioreg dump to leverage")
+    if os.name == "nt":
+        parser.add_argument("-n", "--include-names", help="include friendly names for devices where applicable (Windows only)",action="store_true")
+    else:
+        parser.add_argument("-i", "--local-ioreg", help="path to local ioreg dump to leverage (macOS Only)")
     parser.add_argument("-c", "--column-list", help="comma delimited list of numbers representing which columns to display.  Options are:\n{}".format(available))
     parser.add_argument("-m", "--column-match", help="match entry formatted as NUM=VAL.  e.g. To match all bridged devices: 4=YES",action="append",nargs="*")
+    
     args = parser.parse_args()
-    if args.local_ioreg:
+    
+    if sys.platform.lower() == "darwin" and args.local_ioreg:
         ioreg_path = p.u.check_path(args.local_ioreg)
         if not ioreg_path:
             print("'{}' does not exist!".format(args.local_ioreg))
@@ -226,4 +411,9 @@ if __name__ == '__main__':
         if not column_match:
             print("Invalid column match information passed.")
             exit(1)
-    p.main(device_name=args.find_name,columns=columns,column_match=column_match)
+    p.main(
+        device_name=args.find_name,
+        columns=columns,
+        column_match=column_match,
+        include_names=getattr(args,"include_names",False)
+    )


### PR DESCRIPTION
It's ugly, and powershell is terribly slow - but this does seem to give more-or-less the same output as macOS.  This does not check for a built-in property, as I don't think that's visible from Windows.  It also cannot use the `-i` switch for a local ioreg file.  It does add a Windows-only switch though, `-n` which displays the friendly name for each device if found.